### PR TITLE
Document Binance v3 endpoints for bots

### DIFF
--- a/src/api/v3/orders/types.rs
+++ b/src/api/v3/orders/types.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use serde::Deserialize;
+use utoipa::{IntoParams, ToSchema};
 
 use crate::dto::orders::NewOrderRequest;
 
@@ -11,57 +12,127 @@ pub enum NewOrderPayload {
     Binance(BinanceNewOrderParams),
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, IntoParams, ToSchema)]
 #[serde(rename_all = "camelCase")]
+#[into_params(parameter_in = Query, rename_all = "camelCase")]
 pub struct BinanceNewOrderParams {
+    /// Trading pair symbol, e.g. ETHBTC.
+    #[param(required = true)]
+    #[schema(required = true, example = "ETHBTC")]
     pub symbol: Option<String>,
+    /// Order side. Allowed values: BUY or SELL.
+    #[param(required = true)]
+    #[schema(required = true, example = "BUY")]
     pub side: Option<String>,
     #[serde(rename = "type")]
+    /// Order type. LIMIT requires timeInForce, price and quantity. MARKET requires either quantity or quoteOrderQty.
+    #[param(required = true)]
+    #[schema(required = true, example = "LIMIT")]
     pub order_type: Option<String>,
+    /// Required when type=LIMIT. Only GTC is supported.
     pub time_in_force: Option<String>,
+    /// Required for LIMIT orders and for MARKET when quoteOrderQty is not provided.
     pub quantity: Option<String>,
+    /// Mutually exclusive with quantity for MARKET orders. Total quote amount to trade.
     pub quote_order_qty: Option<String>,
+    /// Required for LIMIT orders. Price per unit.
     pub price: Option<String>,
+    /// Optional timestamp in milliseconds for Binance compatibility.
+    #[param(value_type = i64, format = Int64)]
+    #[schema(value_type = i64, format = Int64)]
     pub timestamp: Option<String>,
+    /// Optional recvWindow in milliseconds. Ignored if present.
+    #[param(value_type = i64, format = Int64)]
+    #[schema(value_type = i64, format = Int64)]
     pub recv_window: Option<String>,
+    /// Optional client-defined order identifier.
     pub new_client_order_id: Option<String>,
+    /// Response type hint. Supported values: ACK, RESULT, FULL.
     pub new_order_resp_type: Option<String>,
+    /// Optional session identifier. If omitted, X-Session-Id header is used.
     pub session_id: Option<String>,
+    /// Signature parameter is accepted for compatibility but ignored.
     pub signature: Option<String>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, IntoParams, ToSchema)]
 #[serde(rename_all = "camelCase")]
+#[into_params(parameter_in = Query, rename_all = "camelCase")]
 pub struct BinanceQueryParams {
+    /// Trading pair symbol. Required when querying by symbol only endpoints.
     pub symbol: Option<String>,
+    /// Numeric identifier of the order (int64).
+    #[param(value_type = i64, format = Int64)]
+    #[schema(value_type = i64, format = Int64)]
     pub order_id: Option<String>,
+    /// Original client order identifier. Provide either orderId or origClientOrderId.
     pub orig_client_order_id: Option<String>,
+    /// Optional timestamp in milliseconds for Binance compatibility.
+    #[param(value_type = i64, format = Int64)]
+    #[schema(value_type = i64, format = Int64)]
     pub timestamp: Option<String>,
+    /// Optional recvWindow in milliseconds. Ignored if present.
+    #[param(value_type = i64, format = Int64)]
+    #[schema(value_type = i64, format = Int64)]
     pub recv_window: Option<String>,
+    /// Optional session identifier. If omitted, X-Session-Id header is used.
     pub session_id: Option<String>,
+    /// Signature parameter is accepted for compatibility but ignored.
     pub signature: Option<String>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, IntoParams, ToSchema)]
 #[serde(rename_all = "camelCase")]
+#[into_params(parameter_in = Query, rename_all = "camelCase")]
 pub struct BinanceOpenOrdersParams {
+    /// Optional trading pair symbol. When omitted, all open orders are returned.
     pub symbol: Option<String>,
+    /// Optional timestamp in milliseconds for Binance compatibility.
+    #[param(value_type = i64, format = Int64)]
+    #[schema(value_type = i64, format = Int64)]
     pub timestamp: Option<String>,
+    /// Optional recvWindow in milliseconds. Ignored if present.
+    #[param(value_type = i64, format = Int64)]
+    #[schema(value_type = i64, format = Int64)]
     pub recv_window: Option<String>,
+    /// Optional session identifier. If omitted, X-Session-Id header is used.
     pub session_id: Option<String>,
+    /// Signature parameter is accepted for compatibility but ignored.
     pub signature: Option<String>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, IntoParams, ToSchema)]
 #[serde(rename_all = "camelCase")]
+#[into_params(parameter_in = Query, rename_all = "camelCase")]
 pub struct BinanceMyTradesParams {
+    /// Trading pair symbol to query trades for.
+    #[param(required = true)]
+    #[schema(required = true)]
     pub symbol: Option<String>,
+    /// Optional start time in milliseconds.
+    #[param(value_type = i64, format = Int64)]
+    #[schema(value_type = i64, format = Int64)]
     pub start_time: Option<String>,
+    /// Optional end time in milliseconds.
+    #[param(value_type = i64, format = Int64)]
+    #[schema(value_type = i64, format = Int64)]
     pub end_time: Option<String>,
+    /// Optional trade id to fetch from.
+    #[param(value_type = i64, format = Int64)]
+    #[schema(value_type = i64, format = Int64)]
     pub from_id: Option<String>,
+    /// Optional max number of trades to return (default 500, max 1000).
     pub limit: Option<String>,
+    /// Optional timestamp in milliseconds for Binance compatibility.
+    #[param(value_type = i64, format = Int64)]
+    #[schema(value_type = i64, format = Int64)]
     pub timestamp: Option<String>,
+    /// Optional recvWindow in milliseconds. Ignored if present.
+    #[param(value_type = i64, format = Int64)]
+    #[schema(value_type = i64, format = Int64)]
     pub recv_window: Option<String>,
+    /// Optional session identifier. If omitted, X-Session-Id header is used.
     pub session_id: Option<String>,
+    /// Signature parameter is accepted for compatibility but ignored.
     pub signature: Option<String>,
 }

--- a/src/app/router.rs
+++ b/src/app/router.rs
@@ -1,13 +1,14 @@
 use axum::{routing::get, Json, Router};
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
-use utoipa::OpenApi;
+use utoipa::{openapi::OpenApi as OpenApiDoc, OpenApi};
 
 use crate::{api, oas::ApiDoc};
 
 pub fn create_router() -> Router {
     let openapi = ApiDoc::openapi();
+    let v3_doc: OpenApiDoc = crate::oas::BinanceV3Api::openapi();
 
-    Router::new()
+    let app = Router::new()
         .route(
             "/api-docs/openapi.json",
             get({
@@ -17,7 +18,17 @@ pub fn create_router() -> Router {
         )
         .route("/ping", get(crate::api::errors::ping))
         .merge(api::v1::router())
-        .merge(api::v3::router())
+        .merge(api::v3::router());
+
+    let v3_json = Router::new().route(
+        "/api-docs/openapi.v3.json",
+        get({
+            let v3_doc = v3_doc.clone();
+            move || async { Json(v3_doc) }
+        }),
+    );
+
+    app.merge(v3_json)
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
 }

--- a/src/dto/v3/account.rs
+++ b/src/dto/v3/account.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
+use utoipa::ToSchema;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct BinanceAccountResponse {
     pub maker_commission: i32,
@@ -17,7 +18,7 @@ pub struct BinanceAccountResponse {
     pub permissions: Vec<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct BinanceBalance {
     pub asset: String,

--- a/src/dto/v3/error.rs
+++ b/src/dto/v3/error.rs
@@ -1,7 +1,16 @@
 use axum::{http::StatusCode, response::IntoResponse, Json};
 use serde::Serialize;
+#[allow(unused_imports)]
+use serde_json::json;
+use utoipa::ToSchema;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
+#[schema(
+    example = json!({
+        "code": -1102,
+        "msg": "Mandatory parameter was not sent, was empty/null, or malformed."
+    })
+)]
 pub struct BinanceErrorResponse {
     pub code: i32,
     pub msg: String,

--- a/src/dto/v3/orders.rs
+++ b/src/dto/v3/orders.rs
@@ -1,20 +1,21 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize, ToSchema)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum BinanceOrderSide {
     Buy,
     Sell,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize, ToSchema)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum BinanceOrderType {
     Market,
     Limit,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize, ToSchema)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum BinanceTimeInForce {
     Gtc,
@@ -28,7 +29,7 @@ impl BinanceTimeInForce {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize, ToSchema)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum NewOrderRespType {
     Ack,
@@ -42,11 +43,13 @@ impl Default for NewOrderRespType {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct BinanceNewOrderResponse {
     pub symbol: String,
+    #[schema(value_type = i64, format = Int64)]
     pub order_id: u64,
+    #[schema(value_type = i64, format = Int64)]
     pub order_list_id: i64,
     pub client_order_id: Option<String>,
     pub transact_time: i64,
@@ -71,7 +74,7 @@ pub struct BinanceNewOrderResponse {
     pub fills: Option<Vec<BinanceOrderFill>>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct BinanceOrderFill {
     pub price: String,
@@ -81,10 +84,11 @@ pub struct BinanceOrderFill {
     pub trade_id: u64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct BinanceOrderDetails {
     pub symbol: String,
+    #[schema(value_type = i64, format = Int64)]
     pub order_id: u64,
     pub order_list_id: i64,
     pub client_order_id: Option<String>,

--- a/src/dto/v3/trades.rs
+++ b/src/dto/v3/trades.rs
@@ -1,11 +1,14 @@
 use serde::Serialize;
+use utoipa::ToSchema;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct BinanceTradeResponse {
     pub symbol: String,
     pub id: u64,
+    #[schema(value_type = i64, format = Int64)]
     pub order_id: u64,
+    #[schema(value_type = i64, format = Int64)]
     pub order_list_id: i64,
     pub price: String,
     pub qty: String,

--- a/src/oas/mod.rs
+++ b/src/oas/mod.rs
@@ -1,3 +1,7 @@
+pub mod v3;
+
+pub use v3::BinanceV3Api;
+
 use utoipa::OpenApi;
 
 use crate::dto;
@@ -27,14 +31,6 @@ use crate::dto;
         crate::api::v1::sessions::enable_session,
         crate::api::v1::sessions::disable_session,
         crate::api::v1::sessions::delete_session,
-        // Orders (compat)
-        crate::api::v3::orders::new_order,
-        crate::api::v3::orders::get_order,
-        crate::api::v3::orders::cancel_order,
-        crate::api::v3::orders::open_orders,
-        crate::api::v3::orders::my_trades,
-        // Account
-        crate::api::v3::account::get_account,
         // Binance proxy (opcional)
         crate::api::v1::market_binance::symbols,
         crate::api::v1::market_binance::intervals,

--- a/src/oas/v3.rs
+++ b/src/oas/v3.rs
@@ -1,0 +1,48 @@
+use utoipa::OpenApi;
+
+const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Exchange Simulator — Binance v3 (Bots)",
+        description = "Spec para endpoints compatibles con Binance usados por bots (ordenes, cuenta, trades)."
+    ),
+    paths(
+        crate::api::v3::orders::handlers::new_order,
+        crate::api::v3::orders::handlers::get_order,
+        crate::api::v3::orders::handlers::cancel_order,
+        crate::api::v3::orders::handlers::open_orders,
+        crate::api::v3::orders::handlers::my_trades,
+        crate::api::v3::account::get_account
+    ),
+    components(schemas(
+        crate::api::v3::orders::types::BinanceNewOrderParams,
+        crate::api::v3::orders::types::BinanceQueryParams,
+        crate::api::v3::orders::types::BinanceOpenOrdersParams,
+        crate::api::v3::orders::types::BinanceMyTradesParams,
+        crate::api::v3::account::BinanceAccountParams,
+        crate::dto::v3::orders::BinanceNewOrderResponse,
+        crate::dto::v3::orders::BinanceOrderDetails,
+        crate::dto::v3::orders::BinanceOrderFill,
+        crate::dto::v3::orders::BinanceOrderSide,
+        crate::dto::v3::orders::BinanceOrderType,
+        crate::dto::v3::orders::BinanceTimeInForce,
+        crate::dto::v3::orders::NewOrderRespType,
+        crate::dto::v3::trades::BinanceTradeResponse,
+        crate::dto::v3::account::BinanceAccountResponse,
+        crate::dto::v3::account::BinanceBalance,
+        crate::dto::v3::error::BinanceErrorResponse
+    )),
+    tags((name = "binance-v3", description = "Endpoints Binance-like para bots")),
+    modifiers(&BinanceV3DocModifier)
+)]
+pub struct BinanceV3Api;
+
+struct BinanceV3DocModifier;
+
+impl utoipa::Modify for BinanceV3DocModifier {
+    fn modify(&self, doc: &mut utoipa::openapi::OpenApi) {
+        doc.info.version = PKG_VERSION.to_string();
+    }
+}


### PR DESCRIPTION
## Summary
- document Binance v3 request parameters with schema metadata so OpenAPI renders numeric fields and optional compatibility flags correctly
- enrich v3 order/account handlers with form-urlencoded request body examples, Binance-style response annotations, and error examples for bots

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d5dbe9ef08832b9c4d87b707c05bff